### PR TITLE
Fix race conditions allocating OFPort numbers when servicing simultaneous Join requests, and deleting a container when the network is gone.

### DIFF
--- a/lib_test.sh
+++ b/lib_test.sh
@@ -37,6 +37,7 @@ clean_dirs()
 	./graph_dovesnap/graph_dovesnap.py -o /tmp/dovesnapviz || exit 1
 	docker rm -f testcon || exit 1
 	docker network rm testnet || exit 1
+	sleep 2
 	FAUCET_PREFIX=$TMPDIR docker-compose -f docker-compose.yml -f docker-compose-standalone.yml stop
 	rm -rf $TMPDIR
 }

--- a/ovs/ovs_bridge.go
+++ b/ovs/ovs_bridge.go
@@ -149,18 +149,18 @@ func (ovsdber *ovsdber) createBridge(bridgeName string, controller string, dpid 
 }
 
 //  setup bridge, if bridge does not exist create it.
-func (d *Driver) initBridge(id string, controller string, dpid string, add_ports string, userspace bool) error {
-	bridgeName := d.networks[id].BridgeName
+func (d *Driver) initBridge(ns NetworkState, controller string, dpid string, add_ports string, userspace bool) error {
+	bridgeName := ns.BridgeName
 	err := d.ovsdber.createBridge(bridgeName, controller, dpid, add_ports, false, userspace)
 	if err != nil {
 		log.Errorf("Error creating bridge: %s", err)
 		return err
 	}
-	bridgeMode := d.networks[id].Mode
+	bridgeMode := ns.Mode
 	switch bridgeMode {
 	case modeNAT:
 		{
-			gatewayIP := d.networks[id].Gateway + "/" + d.networks[id].GatewayMask
+			gatewayIP := ns.Gateway + "/" + ns.GatewayMask
 			if err := setInterfaceIP(bridgeName, gatewayIP); err != nil {
 				log.Debugf("Error assigning address: %s on bridge: %s with an error of: %s", gatewayIP, bridgeName, err)
 			}


### PR DESCRIPTION
Docker can issue us parallel Join requests. Because we did not have a lock on OVSDB, we could allocate the same OFPort for both containers.

Docker network delete/and creates were also issued immediately, rather than waiting for dovesnap to deal with any outstanding container Join or Leave requests. Now Create and Delete network operations are serialized for correct operation.

time="2020-09-17T08:03:33Z" level=debug msg="OK: [dump-ports-desc ovsbr-40daa]"
time="2020-09-17T08:03:33Z" level=debug msg="existing ports on ovsbr-40daa: [1 2]"
time="2020-09-17T08:03:33Z" level=debug msg="OK: [dump-ports-desc ovsbr-40daa]"
time="2020-09-17T08:03:33Z" level=debug msg="existing ports on ovsbr-40daa: [1 2]"
time="2020-09-17T08:03:33Z" level=debug msg="OK: [--db=unix:/var/run/openvswitch/db.sock add-port ovsbr-40daa ovs-veth0-06dd4 -- set Interface ovs-veth0-06dd4 ofport_request=3]"
time="2020-09-17T08:03:33Z" level=info msg="Attached veth [ ovs-veth0-06dd4 ] to bridge [ ovsbr-40daa ] ofport 3"
time="2020-09-17T08:03:33Z" level=debug msg="Join endpoint 40daa5b63029cfc44821adf7ddb4be3d6a0a71efece17dab1ca9ac352c487c59:06dd4b7553a58b9ecd2fe3673517642239444b8299be9a0b377493e5eafe1c14 to /var/run/docker/netns/d0a65696da8e"
time="2020-09-17T08:03:33Z" level=debug msg="OK: [--db=unix:/var/run/openvswitch/db.sock add-port ovsbr-40daa ovs-veth0-d3be2 -- set Interface ovs-veth0-d3be2 ofport_request=3]"
time="2020-09-17T08:03:33Z" level=info msg="Attached veth [ ovs-veth0-d3be2 ] to bridge [ ovsbr-40daa ] ofport 3"