### PR TITLE
Add webserver, and json endpoint that serves current network/containerr state on :9401 by default.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/lib_test.sh
+++ b/lib_test.sh
@@ -44,6 +44,7 @@ init_dirs()
 
 clean_dirs()
 {
+	wget -q -O- localhost:9401/networks |jq || exit 1
 	./graph_dovesnap/graph_dovesnap.py -o /tmp/dovesnapviz || exit 1
 	docker rm -f testcon || exit 1
 	docker network rm testnet || exit 1

--- a/lib_test.sh
+++ b/lib_test.sh
@@ -44,7 +44,7 @@ init_dirs()
 
 clean_dirs()
 {
-	wget -q -O- localhost:9401/networks |jq || exit 1
+	wget -q -O- localhost:9401/networks || exit 1
 	./graph_dovesnap/graph_dovesnap.py -o /tmp/dovesnapviz || exit 1
 	docker rm -f testcon || exit 1
 	docker network rm testnet || exit 1

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ func main() {
 		"mirror_bridge_in", "", "optional input interface from another mirror bridge")
 	flagMirrorBridgeOut := flag.String(
 		"mirror_bridge_out", "", "output interface from mirror bridge")
+	flagStatusServerPort := flag.Int(
+		"status_port", 9401, "port for status server")
 	flag.Parse()
 	if *flagDebug {
 		log.SetLevel(log.DebugLevel)
@@ -45,7 +47,8 @@ func main() {
 		*flagStackMirrorInterface,
 		*flagDefaultControllers,
 		*flagMirrorBridgeIn,
-		*flagMirrorBridgeOut)
+		*flagMirrorBridgeOut,
+		*flagStatusServerPort)
 	log.Infof("New Docker driver created")
 	h := network.NewHandler(d)
 	log.Infof("Getting ready to serve new Docker driver")

--- a/ovs/ovs_config.go
+++ b/ovs/ovs_config.go
@@ -343,6 +343,8 @@ func getNetworkStateFromResource(r *types.NetworkResource) (ns NetworkState, err
 		Gateway:           gateway,
 		GatewayMask:       mask,
 		NATAcl:            getStrOptionFromResource(r, NATAclOption, ""),
+		Containers:        make(map[string]ContainerState),
+		ExternalPorts:     make(map[string]ExternalPortState),
 	}
 	return
 }


### PR DESCRIPTION
This will allow portunus and the viz script to eventually only have to consult one source of network state truth, with all information already correlated without having to do time consuming docker inspecting and screenscraping.

Still to do: MAC addresses, keep DHCP addresses up to date, and internal patch/mirror ports.

JSON logging may not be necessary past this point.

wget -q -O- localhost:9401/networks|jq
{
  "325b12cd37bd8808afe9d9b875a3e351ef25b763b8c48029f741d60da2dc141f": {
    "NetworkName": "testnet",
    "BridgeName": "ovsbr-325b1",
    "BridgeDpid": "0x1",
    "BridgeDpidUint": 1,
    "BridgeVLAN": 100,
    "MTU": 1500,
    "Mode": "nat",
    "AddPorts": "",
    "Gateway": "172.27.0.1",
    "GatewayMask": "16",
    "FlatBindInterface": "",
    "UseDHCP": false,
    "Userspace": false,
    "NATAcl": "",
    "Containers": {
      "4f2ff1cf74e2e9192940503c33bb1bedd388c7a04cc0fa4660f61db4a8f6e818": {
        "Name": "/testcon",
        "Id": "a11b88544fff11db7438c667205f6c6510c31f7747e7933f6f45ced5e5fcabfb",
        "OFPort": 1,
        "HostIP": "172.27.0.2",
        "Labels": {
          "dovesnap.faucet.portacl": "ratelimitit"
        }
      }
    },
    "ExternalPorts": {}
  }
}