### PR TITLE
Make delete network, a blocking call

### DIFF
--- a/ovs/driver.go
+++ b/ovs/driver.go
@@ -357,6 +357,7 @@ func (d *Driver) DeleteNetwork(r *networkplugin.DeleteNetworkRequest) error {
 	}
 
 	d.dovesnapOpChan <- deleteMsg
+	d.blockUntilStateSynched()
 	return nil
 }
 
@@ -936,6 +937,16 @@ func mustHandleNetworks(d *Driver) {
 		panic(err)
 	}
 	d.webResponseChan <- fmt.Sprintf("%s", encodedMsg)
+}
+
+func (d *Driver) stateSynched() bool {
+	return len(d.dovesnapOpChan) == 0
+}
+
+func (d *Driver) blockUntilStateSynched() {
+	for !d.stateSynched() {
+		time.Sleep(time.Second)
+	}
 }
 
 func (d *Driver) resourceManager() {

--- a/ovs/driver.go
+++ b/ovs/driver.go
@@ -415,8 +415,6 @@ func (d *Driver) DiscoverDelete(r *networkplugin.DiscoveryNotification) error {
 
 func (d *Driver) DeleteEndpoint(r *networkplugin.DeleteEndpointRequest) error {
 	log.Debugf("Delete endpoint request: %+v", r)
-	localVethPair := vethPair(truncateID(r.EndpointID))
-	delVethPair(localVethPair)
 	return nil
 }
 


### PR DESCRIPTION
Since we know all required state to execute the delete, we can block until the delete operation (and all other pending work) is done, so once delete network is done it is safe to stop dovesnap.
