### PR TITLE
startup/shutdown handling improvements.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     extra_hosts:
       - 'faucetconfrpc:${FAUCETCONFRPC_IP}'
     depends_on:
-      - ovs
+      ovs:
+        condition: service_healthy
     cap_add:
       - NET_ADMIN
     privileged: true
@@ -33,6 +34,8 @@ services:
   ovs:
     restart: always
     image: iqtlabs/openvswitch:v2.14.2
+    healthcheck:
+      test: 'ovs-vsctl show'
     volumes:
       - /usr/local/var/run/openvswitch:/usr/local/var/run/openvswitch
       - ovs-data:/etc/openvswitch

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"flag"
+	"os"
+	"os/signal"
+	"syscall"
 
 	ovs "dovesnap/ovs"
 	"github.com/docker/go-plugins-helpers/network"
@@ -23,6 +26,8 @@ func main() {
 		"faucetconfrpc_port", 59999, "port for faucetconfrpc server")
 	flagFaucetconfrpcKeydir := flag.String(
 		"faucetconfrpc_keydir", "/faucetconfrpc", "directory with keys for faucetconfrpc server")
+	flagFaucetconfrpcConnRetries := flag.Int(
+		"faucetconfrpc_connretries", 5, "number of retries to connect to faucetconfrpc server")
 	flagStackingInterfaces := flag.String(
 		"stacking_interfaces", "", "comma separated list of [dpname:port:interface_name] to use for stacking")
 	flagStackPriority1 := flag.String(
@@ -53,6 +58,7 @@ func main() {
 		*flagFaucetconfrpcServerName,
 		*flagFaucetconfrpcServerPort,
 		*flagFaucetconfrpcKeydir,
+		*flagFaucetconfrpcConnRetries,
 		*flagStackPriority1,
 		*flagStackingInterfaces,
 		*flagStackMirrorInterface,
@@ -64,5 +70,15 @@ func main() {
 	log.Infof("New Docker driver created")
 	h := network.NewHandler(d)
 	log.Infof("Getting ready to serve new Docker driver")
-	h.ServeUnix(ovs.DriverName, 0)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM)
+	go func() {
+		h.ServeUnix(ovs.DriverName, 0)
+		log.Errorf("Unexpected server exit")
+		os.Exit(1)
+	}()
+	sig := <-sigChan
+	log.Infof("Caught signal %v", sig)
+	d.BlockUntilStateSynched()
+	os.Exit(0)
 }

--- a/ovs/driver.go
+++ b/ovs/driver.go
@@ -357,7 +357,7 @@ func (d *Driver) DeleteNetwork(r *networkplugin.DeleteNetworkRequest) error {
 	}
 
 	d.dovesnapOpChan <- deleteMsg
-	d.blockUntilStateSynched()
+	d.BlockUntilStateSynched()
 	return nil
 }
 
@@ -941,7 +941,7 @@ func (d *Driver) stateSynched() bool {
 	return len(d.dovesnapOpChan) == 0
 }
 
-func (d *Driver) blockUntilStateSynched() {
+func (d *Driver) BlockUntilStateSynched() {
 	for !d.stateSynched() {
 		time.Sleep(time.Second)
 	}
@@ -1080,7 +1080,7 @@ func (d *Driver) runWeb(port int) {
 	}
 }
 
-func NewDriver(flagFaucetconfrpcClientName string, flagFaucetconfrpcServerName string, flagFaucetconfrpcServerPort int, flagFaucetconfrpcKeydir string, flagStackPriority1 string, flagStackingInterfaces string, flagStackMirrorInterface string, flagDefaultControllers string, flagMirrorBridgeIn string, flagMirrorBridgeOut string, flagStatusServerPort int, flagStatusAuthIPs string) *Driver {
+func NewDriver(flagFaucetconfrpcClientName string, flagFaucetconfrpcServerName string, flagFaucetconfrpcServerPort int, flagFaucetconfrpcKeydir string, flagFaucetconfrpcConnRetries int, flagStackPriority1 string, flagStackingInterfaces string, flagStackMirrorInterface string, flagDefaultControllers string, flagMirrorBridgeIn string, flagMirrorBridgeOut string, flagStatusServerPort int, flagStatusAuthIPs string) *Driver {
 	log.Infof("Initializing dovesnap")
 	ensureDirExists(netNsPath)
 
@@ -1122,7 +1122,12 @@ func NewDriver(flagFaucetconfrpcClientName string, flagFaucetconfrpcServerName s
 	d.mirrorBridgeName = d.mustGetMirrorBrName()
 	d.loopbackBridgeName = d.mustGetLoopbackBrName()
 	d.stackDpName = d.mustGetStackDPName()
-	d.faucetconfrpcer.mustGetGRPCClient(flagFaucetconfrpcClientName, flagFaucetconfrpcServerName, flagFaucetconfrpcServerPort, flagFaucetconfrpcKeydir)
+	d.faucetconfrpcer.mustGetGRPCClient(
+		flagFaucetconfrpcClientName,
+		flagFaucetconfrpcServerName,
+		flagFaucetconfrpcServerPort,
+		flagFaucetconfrpcKeydir,
+		flagFaucetconfrpcConnRetries)
 
 	d.ovsdber.waitForOvs()
 

--- a/tests/lib_test.sh
+++ b/tests/lib_test.sh
@@ -64,13 +64,17 @@ clean_dirs()
         sudo ./graph_dovesnap/graph_dovesnap -o /tmp/dovesnapviz || exit 1
         docker rm -f testcon || exit 1
         docker network rm testnet || exit 1
-        sleep 2
         FAUCET_PREFIX=$TMPDIR docker-compose -f docker-compose.yml -f docker-compose-standalone.yml stop
         rm -rf $TMPDIR
         VETHS="$(ip link | grep -E ':( ovs-veth|ovp)')"
         if [ "$VETHS" != "" ] ; then
                 echo veths leaked: $VETHS
                 exit 1
+        fi
+        DIEC=$(docker system events --since=15m --until=0m --filter="container=dovesnap_plugin_1" --filter="event=die" | grep -v exitCode=0)
+        if [ "$DIEC" != "" ] ; then
+               echo dovesnap exited unexpectedly: $DIEC
+               exit 1
         fi
 }
 


### PR DESCRIPTION
* test that dovesnap plugin didn't crash during tests
* retry faucetconfrpc initial connection
* wait for OVS to be up and running
* flush any pending transactions on a "docker restart" or "docker stop".