### PR TITLE
Change 1.1.15 poetry constraint which new renovate does not recognize.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "constraints": {
-    "poetry": "==1.1.15"
+    "poetry": "1.1.15"
   },
   "extends": [
     "config:base"


### PR DESCRIPTION
Not a semver like version - aborting: ==1.1.15